### PR TITLE
telemetryDistroName Key added to distinguish service metadata comming for language specific opentelemetry agent or opentelemetry eBPF/OBI agent

### DIFF
--- a/exporter/metadataexporter/exporter.go
+++ b/exporter/metadataexporter/exporter.go
@@ -65,6 +65,7 @@ type serviceMetadata struct {
 	TelemetrySDKLanguage      string `json:"telemetrySdkLanguage"`
 	TelemetrySDKName          string `json:"telemetrySdkName"`
 	TelemetrySDKVersion       string `json:"telemetrySdkVersion"`
+	TelemetryDistroName       string `json:"telemetryDistroName"`
 	ContainerID               string `json:"containerId"`
 	Timestamp                 int64  `json:"timestamp"`
 }
@@ -275,6 +276,7 @@ func (e *metadataExporter) extractMetadata(resource pcommon.Resource, now time.T
 		TelemetrySDKLanguage:      stringAttr(attrs, "telemetry.sdk.language"),
 		TelemetrySDKName:          stringAttr(attrs, "telemetry.sdk.name"),
 		TelemetrySDKVersion:       stringAttr(attrs, "telemetry.sdk.version"),
+		TelemetryDistroName:       stringAttr(attrs, "telemetry.distro.name"),
 		ContainerID:               stringAttr(attrs, "container.id"),
 		Timestamp:                 now.UnixMilli(),
 	}

--- a/exporter/metadataexporter/exporter_test.go
+++ b/exporter/metadataexporter/exporter_test.go
@@ -80,6 +80,7 @@ func TestExtractMetadata(t *testing.T) {
 	attrs.PutStr("telemetry.sdk.language", "java")
 	attrs.PutStr("telemetry.sdk.name", "opentelemetry")
 	attrs.PutStr("telemetry.sdk.version", "1.35.0")
+	attrs.PutStr("telemetry.distro.name", "opentelemetry-ebpf-instrumentation")
 	attrs.PutStr("container.id", "container-123")
 
 	got := testExporter().extractMetadata(res, now)
@@ -100,6 +101,7 @@ func TestExtractMetadata(t *testing.T) {
 		TelemetrySDKLanguage:      "java",
 		TelemetrySDKName:          "opentelemetry",
 		TelemetrySDKVersion:       "1.35.0",
+		TelemetryDistroName:       "opentelemetry-ebpf-instrumentation",
 		ContainerID:               "container-123",
 		Timestamp:                 1710000000000,
 	}, got)


### PR DESCRIPTION
### PR Description

#### Summary

Adds support for exporting the `telemetry.distro.name` resource attribute as part of the service metadata payload. The attribute is exposed as `telemetryDistroName` in the exported JSON and is populated from the OpenTelemetry resource metadata when available.

#### Changes

* Added `TelemetryDistroName` field (`json:"telemetryDistroName"`) to the `serviceMetadata` struct.
* Extracted and populated the value from the `telemetry.distro.name` resource attribute during metadata extraction.
* Updated `TestExtractMetadata` to validate extraction of `telemetry.distro.name`.

#### Why

OpenTelemetry distributions (e.g., OpenTelemetry eBPF Instrumentation) identify themselves using the `telemetry.distro.name` semantic convention. Exporting this information enables downstream consumers to distinguish the instrumentation distribution used by a service, in addition to the underlying OpenTelemetry SDK details.

#### Behavior

* Backward compatible.
* If `telemetry.distro.name` is not present, `telemetryDistroName` remains empty.
* No configuration changes required.

#### Testing

* Updated and verified `TestExtractMetadata` to cover the new attribute extraction logic.
